### PR TITLE
Workaround to show input delay in char select screen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ titleid = "01006A800016E000" # Smash Ultimate
 crate-type = ["cdylib"]
 
 [dependencies]
-ninput = { git = "https://github.com/blu-dev/ninput", version = "0.1.0" }
-skyline = "0.2.0"
+ninput = { git = "https://github.com/blu-dev/ninput" }
+skyline = { git = "https://github.com/ultimate-research/skyline-rs" }
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
Before this, the delay display was only showing on p1 (room host) side, and was not showing on p2 (room client) side.
Not sure exactly, what was causing this, since I'm pretty sure they both are the same text pane. Maybe the game was updating the pane somewhere else and that was overwriting my changes.

Anyways this PR hooks on to ui2d::draw and if we are in the char select screen, it finds the pane and sets the text.