### PR TITLE
Replace p2 workaround with actual solution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "local-latency-slider"
-version = "1.1.1"
-authors = []
+version = "1.2.0"
+authors = ["blu-dev", "saad-script"]
 edition = "2021"
 
 [package.metadata.skyline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ const MIN_INPUT_BUFFER: isize = -1;
 #[skyline::from_offset(0x37a1270)]
 unsafe fn set_text_string(pane: u64, string: *const u8);
 
-
 unsafe fn poll_input_update_delay() {
     static mut CURRENT_COUNTER: usize = 0;
     if ninput::any::is_press(ninput::Buttons::RIGHT) {
@@ -40,13 +39,13 @@ unsafe fn update_latency_display(header: &str, pane_handle: u64) {
         } else {
             set_text_string(
                 pane_handle,
-                format!("{}Auto ({}f)\0", header, MOST_RECENT_AUTO).as_ptr()
+                format!("{}Auto ({}f)\0", header, MOST_RECENT_AUTO).as_ptr(),
             )
         }
     } else {
         set_text_string(
             pane_handle, 
-            format!("{}{}f\0",header, CURRENT_INPUT_BUFFER).as_ptr()
+            format!("{}{}f\0",header, CURRENT_INPUT_BUFFER).as_ptr(),
         );
     }
 }
@@ -108,7 +107,6 @@ unsafe fn update_css(arg: u64) {
         update_latency_display("Input Delay: ", p1_pane as u64);
         update_latency_display("Input Delay: ", p2_pane as u64);
     }
-
     call_original!(arg);
 }
 


### PR DESCRIPTION
When the mod was first released,, the input delay display wasn't displaying for player 2 (the client).
This was solved by using a workaround in PR https://github.com/saad-script/local-latency-slider/pull/2 and PR https://github.com/saad-script/local-latency-slider/pull/3.

This workaround was clunky and required hooking into ui2d::draw which gets called multiple times per frame (in menu and also in game) and recursively searching for the player 2 text pane. I want the mod to be as lightweight as possible and hooking ui2d::draw seems a bit overkill for doing something so simple.

This PR completely removes this workaround and properly solves the problem by manually going up the layout.arc hierarchy to get the correct pane. Not only does this improve the readability of the code, but also since we are not longer relying on ui2d::draw and no longer recursively searching there might be a small performance boost (although this will most likely not be noticeable)