### PR TITLE
Add framerate options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-latency-slider"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["blu-dev", "saad-script"]
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,40 @@
-I took blue-dev's code for the [orginal arena latency slider mod](https://github.com/blu-dev/arena-latency-slider) and modified it so that it only works with local online. You can see the readme on the original repo to get details as to how exactly the mod works.
+I took blue-dev's code for the [original arena latency slider mod](https://github.com/blu-dev/arena-latency-slider) and modified it so that it only works with local online. I also added in options to change the game's framerate to get even lower input delay. You can see the readme on the original repo to get details as to how exactly the mod changes the online latency.
 
 ## Installation
 
-1) ~~Make sure you have [skyline](https://github.com/skyline-dev/skyline/releases) installed.~~
-(Skyline currently has an issue with LAN/LDN, so check the troubleshooting section below for a workaround for this step)
-
-2) Download the latest `liblocal_latency_slider.nro` from the releases page.
+1) Make sure you have the latest [skyline](https://github.com/skyline-dev/skyline/releases) installed on yuzu.
+2) For skyline to work with LDN, download [this](https://drive.google.com/file/d/1f_idi29L7Poxg0Cljbi4oz9ubpukmdXY/view) and replace the `subsdk9` file in
+```
+%yuzu_folder%/sdmc/atmosphere/contents/01006A800016E000/exefs/subsdk9
+```
+3) Download the latest `liblocal_latency_slider.nro` from the [releases](https://github.com/saad-script/local-latency-slider/releases) page.
 Place it in the corresponding folder. This is how it should look:
 ```
-Yuzu:
 %yuzu_folder%/sdmc/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/liblocal_latency_slider.nro
-
-Ryujinx:
-%ryujinx_folder%/sdcard/atmosphere/contents/01006A800016E000/romfs/skyline/plugins/liblocal_latency_slider.nro
 ```
-
 
 ## Usage
 
-When your in the local online menu or in the character select screen (for local online), you can press DPAD left/right to adjust the delay.
+- This mod is intended for use with the [yuzu](https://yuzu-emu.org/) emulator. Some functionality like the framerate options may not work on a real switch or other emulators.
+- This mod will only work in local online modes. It is intended to be used with yuzu's LDN capabilities to provide an online experience that is very close to the feel of playing offline (and sometimes even identical to offline!)
+- Make sure that yuzu's speed limit is set to 100%. Make sure the previous 120 fps cheat is disabled/removed.
+- Due to a current yuzu bug, make sure to connect to LDN **after** launching smash. Otherwise yuzu will crash when loading the game.
+- In the character select screen, you can do any of the following:
+  - Use DPAD left/right to change the online delay set by the game.
+  - Use DPAD up/down to change the target framerate. 120 fps removes 3f of delay, and 240 fps removes 4.5 frames of delay.
+  - Press X to toggle VSYNC on/off (only available when playing on 60 fps). This is useful if you dont have a PC capable of reaching higher framerates like 120 fps, but still want to enjoy the lower delay. This can remove upto 3 frames of delay.
 
-Ideally you would want to use this on an emulator like yuzu and combine it with the 120 fps mod. This will give you very close to native delay when playing online on LDN.
+## Troubleshooting & FAQ
 
+- "I can't enter the local online menu"
+  - Make sure skyline is installed to the correct location and also that you installed the LDN fix in step 2 of the installation instructions.
+- "Yuzu crashes when launching the game"
+  - Make sure to connect to LDN **after** launching smash. If the issue still persists you may have to delete your shaders.
+- "I set the online delay to a low value but the game still feels very slow and stuttery"
+  - Setting the delay too low will cause that. Set the delay based on your proximity to your opponent. Also, both of you should be wired to ethernet on a good network/IPS. You should never set the delay lower than 2f, as that has never worked even on computers wired directly to the same network.
+- "The game seems to speeds up randomly"
+  - Make sure your computer is actually capable of reaching the target framerate. If you have the target framerate set to 120 fps, your PC should be able to maintain a solid 120 fps in game. Also make sure that yuzu's speed limit is set to 100% and that you are not using the previous 120 fps cheat.
+- "There are random stutters that occur in game"
+  - Shader stutters will happen the first time you do a move/action in yuzu. Yuzu will compile and store these shaders so the next time you do the move, it won't stutter. The more you play the less these stutter will happen. It is recommended that you dedicate a game where you and your opponent will hit each other with all of your moves, so in subsequent games these stutters won't occur.
 
-## Troubleshooting
-
-Currently there is an issue with skyline not allowing us to go into the local wireless menu. This requires a workaround:
-
-Yuzu Workaround:
-1) Download this online fix: https://drive.google.com/file/d/1NX8Cbhax3vafTPUpp7r401oZea-Wtmi5/view
-2) Place the files in `%yuzu_folder%/sdmc/atmosphere/contents/01006A800016E000/exefs/`
-3) Open yuzu but DONT connect to yuzu LDN yet. First start smash.
-4) Once your in the smash main menu you can connect to yuzu LDN. It'll give you a warning that the game is already running which you can ignore.
-5) Open the local wireless menu and play.
-
-Ryujinx Workaround:
-1) Download this online fix: https://drive.google.com/file/d/1NX8Cbhax3vafTPUpp7r401oZea-Wtmi5/view
-2) Place the files in `%ryujinx_folder%/sdcard/atmosphere/contents/01006A800016E000/exefs/`
-3) Open Ryujinx (LDN version) and start smash. You should be able to go to the local wireless menu now.
-
+Check out the [NA](https://discord.gg/jE9hTsmbjD) or [EU](https://discord.gg/yuzu-smash-meet-up-1051577844318339172) yuzu smash discord for more information and also matchmaking!

--- a/src/framerate/mod.rs
+++ b/src/framerate/mod.rs
@@ -102,7 +102,7 @@ pub unsafe fn poll() {
 }
 
 pub fn install() {
-    skyline::install_hooks!(scene_update, on_game_speed_calc,);
+    skyline::install_hooks!(scene_update, on_game_speed_calc);
 
     #[skyline::from_offset(0x39bf580)]
     fn get_tick_freq() -> u64;

--- a/src/framerate/mod.rs
+++ b/src/framerate/mod.rs
@@ -1,0 +1,112 @@
+use skyline::hooks::InlineCtx;
+
+use crate::latency;
+use crate::utils;
+
+static mut TARGET_FRAME_RATE: u32 = 60;
+static mut VSYNC_ENABLED: bool = true;
+static mut TICK_FREQ: u64 = 0;
+
+#[skyline::hook(offset = 0x135cad8, inline)]
+unsafe fn on_game_speed_calc(_: &InlineCtx) {
+    if !latency::is_local_online() {
+        return;
+    }
+    set_internal_framerate(3600 / TARGET_FRAME_RATE as u32);
+}
+
+#[skyline::hook(offset = 0x3746afc, inline)]
+unsafe fn scene_update(_: &InlineCtx) {
+    static mut PREV_TICK: Option<skyline::nn::os::Tick> = None;
+    if !latency::is_local_online() {
+        return;
+    }
+    set_framerate_target(TARGET_FRAME_RATE);
+    set_vsync_enabled(VSYNC_ENABLED);
+    if VSYNC_ENABLED {
+        return;
+    }
+    let target_ticks = TICK_FREQ / TARGET_FRAME_RATE as u64;
+    if let Some(prev_tick) = PREV_TICK {
+        loop {
+            let elapsed_ticks = skyline::nn::os::GetSystemTick() - prev_tick;
+            if elapsed_ticks >= target_ticks {
+                break;
+            }
+        }
+    }
+    PREV_TICK = Some(skyline::nn::os::GetSystemTick());
+}
+
+unsafe fn set_swap_interval(swap_interval: i32) {
+    let base_addr = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64;
+    let r = *((base_addr + 0x06D41430) as *const u64);
+    let r = *((r + 0x10) as *const u64);
+    let r = (r + 0xF14) as *mut i32;
+    *r = swap_interval;
+}
+
+unsafe fn set_internal_framerate(internal_framerate: u32) {
+    let base_addr = skyline::hooks::getRegionAddress(skyline::hooks::Region::Text) as u64;
+    let internal_frame_rate_addr = base_addr + 0x523b004;
+    *(internal_frame_rate_addr as *mut u32) = internal_framerate
+}
+
+pub unsafe fn set_framerate_target(framerate_target: u32) {
+    TARGET_FRAME_RATE = framerate_target;
+    set_internal_framerate(3600 / TARGET_FRAME_RATE as u32);
+}
+
+pub unsafe fn set_vsync_enabled(enabled: bool) {
+    VSYNC_ENABLED = enabled;
+    match (VSYNC_ENABLED, TARGET_FRAME_RATE >= 120) {
+        (true, true) => set_swap_interval(-1 * ((TARGET_FRAME_RATE / 120) - 1) as i32),
+        (false, _) => set_swap_interval(-499),
+        _ => set_swap_interval(1),
+    }
+}
+
+pub unsafe fn framerate_target() -> u32 {
+    return TARGET_FRAME_RATE;
+}
+
+pub unsafe fn vsync_enabled() -> bool {
+    return VSYNC_ENABLED;
+}
+
+pub unsafe fn poll() {
+    let pressed_buttons = utils::poll_buttons(vec![
+        ninput::Buttons::UP,
+        ninput::Buttons::DOWN,
+        ninput::Buttons::X,
+    ]);
+    match pressed_buttons {
+        ninput::Buttons::UP => {
+            if VSYNC_ENABLED {
+                TARGET_FRAME_RATE *= 2;
+            }
+        }
+        ninput::Buttons::DOWN => {
+            if VSYNC_ENABLED {
+                TARGET_FRAME_RATE /= 2;
+            }
+        }
+        ninput::Buttons::X => {
+            if TARGET_FRAME_RATE == 60 {
+                VSYNC_ENABLED = !VSYNC_ENABLED;
+            }
+        }
+        _ => (),
+    }
+    TARGET_FRAME_RATE = TARGET_FRAME_RATE.clamp(60, 240);
+}
+
+pub fn install() {
+    skyline::install_hooks!(scene_update, on_game_speed_calc,);
+
+    #[skyline::from_offset(0x39bf580)]
+    fn get_tick_freq() -> u64;
+    unsafe {
+        TICK_FREQ = get_tick_freq();
+    }
+}

--- a/src/latency/mod.rs
+++ b/src/latency/mod.rs
@@ -1,0 +1,129 @@
+use skyline::hooks::InlineCtx;
+
+use crate::framerate;
+use crate::utils;
+
+const MAX_INPUT_BUFFER: u8 = 25;
+
+#[derive(Debug)]
+pub struct Delay {
+    buffer: Buffer,
+    last_auto: Option<u8>,
+}
+
+#[derive(Debug)]
+pub enum Buffer {
+    Auto,
+    Override(u8),
+}
+
+impl Delay {
+    fn next(&mut self) {
+        self.buffer = match &self.buffer {
+            Buffer::Auto => Buffer::Override(0),
+            Buffer::Override(v) => Buffer::Override((*v + 1).min(MAX_INPUT_BUFFER)),
+        }
+    }
+    fn prev(&mut self) {
+        self.buffer = match &self.buffer {
+            Buffer::Auto => Buffer::Auto,
+            Buffer::Override(v) => match v {
+                0 => Buffer::Auto,
+                _ => Buffer::Override(*v - 1),
+            },
+        }
+    }
+    pub fn to_string(&self) -> String {
+        match self.buffer {
+            Buffer::Auto => match self.last_auto {
+                None => "Auto".to_string(),
+                Some(v) => format!("Auto ({}f)", v).to_string(),
+            },
+            Buffer::Override(v) => format!("{}f", v).to_string(),
+        }
+    }
+}
+
+static mut CURRENT_INPUT_DELAY: Delay = Delay {
+    buffer: Buffer::Override(4),
+    last_auto: None,
+};
+static mut IS_LOCAL_ONLINE: bool = false;
+static mut LOCAL_ROOM_PANE_HANDLE: Option<u64> = None;
+
+#[skyline::hook(offset = 0x16cdb08, inline)]
+unsafe fn set_online_latency(ctx: &InlineCtx) {
+    if IS_LOCAL_ONLINE {
+        let auto = *(*ctx.registers[19].x.as_ref() as *mut u8);
+        CURRENT_INPUT_DELAY.last_auto = Some(auto);
+        if let Buffer::Override(v) = CURRENT_INPUT_DELAY.buffer {
+            *(*ctx.registers[19].x.as_ref() as *mut u8) = v;
+        }
+    }
+}
+
+#[skyline::hook(offset = 0x22d91f4, inline)]
+unsafe fn online_melee_any_scene_create(_: &InlineCtx) {
+    IS_LOCAL_ONLINE = false;
+    framerate::set_framerate_target(60);
+    framerate::set_vsync_enabled(true);
+}
+
+#[skyline::hook(offset = 0x22d9124, inline)]
+unsafe fn bg_matchmaking_seq(_: &InlineCtx) {
+    IS_LOCAL_ONLINE = false;
+    framerate::set_framerate_target(60);
+    framerate::set_vsync_enabled(true);
+}
+
+#[skyline::hook(offset = 0x23599b0, inline)]
+unsafe fn main_menu(_: &InlineCtx) {
+    IS_LOCAL_ONLINE = false;
+    framerate::set_framerate_target(60);
+    framerate::set_vsync_enabled(true);
+}
+
+// called on local online menu init
+#[skyline::hook(offset = 0x1bd3ae0, inline)]
+unsafe fn store_local_menu_pane(ctx: &InlineCtx) {
+    IS_LOCAL_ONLINE = true;
+    let handle = *((*((*ctx.registers[0].x.as_ref() + 8) as *const u64) + 0x10) as *const u64);
+    LOCAL_ROOM_PANE_HANDLE = Some(handle);
+}
+
+#[skyline::hook(offset = 0x1bd6f40, inline)]
+unsafe fn update_local_menu(_: &InlineCtx) {
+    if let Some(v) = LOCAL_ROOM_PANE_HANDLE {
+        poll();
+        let delay_str = CURRENT_INPUT_DELAY.to_string();
+        utils::set_text_string(v, format!("{}\0", delay_str).as_ptr());
+    }
+}
+
+pub unsafe fn is_local_online() -> bool {
+    return IS_LOCAL_ONLINE;
+}
+
+pub unsafe fn current_input_delay() -> &'static Delay {
+    return &CURRENT_INPUT_DELAY;
+}
+
+pub unsafe fn poll() {
+    let pressed_buttons = utils::poll_buttons(vec![ninput::Buttons::LEFT, ninput::Buttons::RIGHT]);
+    match pressed_buttons {
+        ninput::Buttons::LEFT => CURRENT_INPUT_DELAY.prev(),
+        ninput::Buttons::RIGHT => CURRENT_INPUT_DELAY.next(),
+        _ => (),
+    }
+}
+
+pub fn install() {
+    skyline::install_hooks!(
+        main_menu,
+        online_melee_any_scene_create,
+        bg_matchmaking_seq,
+        store_local_menu_pane,
+        set_online_latency,
+        update_local_menu,
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,99 +1,12 @@
-use skyline::hooks::InlineCtx;
 use skyline::nn::ui2d::Pane;
 
-static mut CURRENT_INPUT_BUFFER: isize = 4;
-static mut MOST_RECENT_AUTO: isize = -1;
-static mut IS_LOCAL_ONLINE: bool = false;
-
-const MAX_INPUT_BUFFER: isize = 25;
-const MIN_INPUT_BUFFER: isize = -1;
-
-#[skyline::from_offset(0x37a1270)]
-unsafe fn set_text_string(pane: u64, string: *const u8);
-
-unsafe fn poll_input_update_delay() {
-    static mut CURRENT_COUNTER: usize = 0;
-    if ninput::any::is_press(ninput::Buttons::RIGHT) {
-        if CURRENT_COUNTER == 0 {
-            CURRENT_INPUT_BUFFER += 1;
-        }
-        CURRENT_COUNTER = (CURRENT_COUNTER + 1) % 10;
-    } else if ninput::any::is_press(ninput::Buttons::LEFT) {
-        if CURRENT_COUNTER == 0 {
-            CURRENT_INPUT_BUFFER -= 1;
-        }
-        CURRENT_COUNTER = (CURRENT_COUNTER + 1) % 10;
-    } else {
-        CURRENT_COUNTER = 0;
-    }
-    CURRENT_INPUT_BUFFER = CURRENT_INPUT_BUFFER.clamp(MIN_INPUT_BUFFER, MAX_INPUT_BUFFER);
-}
-
-unsafe fn update_latency_display(header: &str, pane_handle: u64) {
-    if CURRENT_INPUT_BUFFER == -1 {
-        if MOST_RECENT_AUTO == -1 {
-            set_text_string(pane_handle, format!("{}Auto\0", header).as_ptr());
-        } else {
-            set_text_string(
-                pane_handle,
-                format!("{}Auto ({}f)\0", header, MOST_RECENT_AUTO).as_ptr(),
-            )
-        }
-    } else {
-        set_text_string(
-            pane_handle,
-            format!("{}{}f\0", header, CURRENT_INPUT_BUFFER).as_ptr(),
-        );
-    }
-}
-
-#[skyline::hook(offset = 0x16cdb08, inline)]
-unsafe fn set_online_latency(ctx: &InlineCtx) {
-    let auto = *(*ctx.registers[19].x.as_ref() as *mut u8);
-    if IS_LOCAL_ONLINE {
-        MOST_RECENT_AUTO = auto as isize;
-        if CURRENT_INPUT_BUFFER != -1 {
-            *(*ctx.registers[19].x.as_ref() as *mut u8) = CURRENT_INPUT_BUFFER as u8;
-        }
-    }
-}
-
-#[skyline::hook(offset = 0x22d91f4, inline)]
-unsafe fn online_melee_any_scene_create(_: &InlineCtx) {
-    IS_LOCAL_ONLINE = false;
-}
-
-#[skyline::hook(offset = 0x22d9124, inline)]
-unsafe fn bg_matchmaking_seq(_: &InlineCtx) {
-    IS_LOCAL_ONLINE = false;
-}
-
-#[skyline::hook(offset = 0x23599b0, inline)]
-unsafe fn main_menu(_: &InlineCtx) {
-    IS_LOCAL_ONLINE = false;
-}
-
-// called on local online menu init
-static mut LOCAL_ROOM_PANE_HANDLE: u64 = 0;
-#[skyline::hook(offset = 0x1bd3ae0, inline)]
-unsafe fn store_local_menu_pane(ctx: &InlineCtx) {
-    IS_LOCAL_ONLINE = true;
-    LOCAL_ROOM_PANE_HANDLE =
-        *((*((*ctx.registers[0].x.as_ref() + 8) as *const u64) + 0x10) as *const u64);
-}
-
-#[skyline::hook(offset = 0x1bd6f40, inline)]
-unsafe fn update_local_menu(_: &InlineCtx) {
-    if LOCAL_ROOM_PANE_HANDLE == 0 {
-        return;
-    }
-    poll_input_update_delay();
-    update_latency_display("", LOCAL_ROOM_PANE_HANDLE);
-}
+mod framerate;
+mod latency;
+mod utils;
 
 #[skyline::hook(offset = 0x1a12460)]
 unsafe fn update_css(arg: u64) {
-    if IS_LOCAL_ONLINE {
+    if latency::is_local_online() {
         // pointer to p1's text pane
         let p1_pane = (*((*((arg + 0xe58) as *const u64) + 0x10) as *const u64)) as *mut Pane;
 
@@ -101,22 +14,30 @@ unsafe fn update_css(arg: u64) {
         let p2_pane_node = (*(*(*(*p1_pane).parent).parent).parent).link.prev;
         let p2_pane = ((p2_pane_node as *mut u64).sub(1)) as *mut Pane;
 
-        poll_input_update_delay();
-        update_latency_display("Input Delay: ", p1_pane as u64);
-        update_latency_display("Input Delay: ", p2_pane as u64);
+        latency::poll();
+        framerate::poll();
+        let delay_str = latency::current_input_delay().to_string();
+        let framerate = framerate::framerate_target();
+        let vsync_str = match framerate::vsync_enabled() {
+            false => String::from("++"),
+            true => String::from(""),
+        };
+        utils::set_text_string(
+            p1_pane as u64,
+            format!("Buffer: {} [{} FPS{}]\0", delay_str, framerate, vsync_str).as_ptr(),
+        );
+        utils::set_text_string(
+            p2_pane as u64,
+            format!("Buffer: {} [{} FPS{}]\0", delay_str, framerate, vsync_str).as_ptr(),
+        );
     }
     call_original!(arg);
 }
 
 #[skyline::main(name = "local-latency-slider")]
-pub unsafe fn main() {
-    skyline::install_hooks!(
-        main_menu,
-        online_melee_any_scene_create,
-        bg_matchmaking_seq,
-        store_local_menu_pane,
-        update_local_menu,
-        set_online_latency,
-        update_css,
-    );
+pub fn main() {
+    framerate::install();
+    latency::install();
+
+    skyline::install_hooks!(update_css,);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,7 @@ unsafe fn poll_input_update_delay() {
 unsafe fn update_latency_display(header: &str, pane_handle: u64) {
     if CURRENT_INPUT_BUFFER == -1 {
         if MOST_RECENT_AUTO == -1 {
-            set_text_string(
-                pane_handle,
-                format!("{}Auto\0", header).as_ptr(),
-            );
+            set_text_string(pane_handle, format!("{}Auto\0", header).as_ptr());
         } else {
             set_text_string(
                 pane_handle,
@@ -44,8 +41,8 @@ unsafe fn update_latency_display(header: &str, pane_handle: u64) {
         }
     } else {
         set_text_string(
-            pane_handle, 
-            format!("{}{}f\0",header, CURRENT_INPUT_BUFFER).as_ptr(),
+            pane_handle,
+            format!("{}{}f\0", header, CURRENT_INPUT_BUFFER).as_ptr(),
         );
     }
 }
@@ -81,7 +78,8 @@ static mut LOCAL_ROOM_PANE_HANDLE: u64 = 0;
 #[skyline::hook(offset = 0x1bd3ae0, inline)]
 unsafe fn store_local_menu_pane(ctx: &InlineCtx) {
     IS_LOCAL_ONLINE = true;
-    LOCAL_ROOM_PANE_HANDLE = *((*((*ctx.registers[0].x.as_ref() + 8) as *const u64) + 0x10) as *const u64);
+    LOCAL_ROOM_PANE_HANDLE =
+        *((*((*ctx.registers[0].x.as_ref() + 8) as *const u64) + 0x10) as *const u64);
 }
 
 #[skyline::hook(offset = 0x1bd6f40, inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,5 +39,5 @@ pub fn main() {
     framerate::install();
     latency::install();
 
-    skyline::install_hooks!(update_css,);
+    skyline::install_hook!(update_css);
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,26 @@
+use std::time::Instant;
+
+#[skyline::from_offset(0x37a1270)]
+pub fn set_text_string(pane: u64, string: *const u8);
+
+pub fn poll_buttons(buttons: Vec<ninput::Buttons>) -> ninput::Buttons {
+    static mut PRESS_COOLDOWN: Option<Instant> = None;
+    for button in buttons {
+        let is_pressed = ninput::any::is_press(button);
+        unsafe {
+            match (PRESS_COOLDOWN, is_pressed) {
+                (Some(t), _) => {
+                    if t.elapsed().as_millis() > 166 {
+                        PRESS_COOLDOWN = None;
+                    }
+                }
+                (None, true) => {
+                    PRESS_COOLDOWN = Some(Instant::now());
+                    return button;
+                }
+                _ => PRESS_COOLDOWN = None,
+            }
+        }
+    }
+    return ninput::Buttons::empty();
+}


### PR DESCRIPTION
Adds ability to change target frame rate + vsync + game speed without the need for any cheat.

Framerate options only work with yuzu. 
Yuzu speed should be set to 100% and any previous fps cheat should be disabled/deleted.

Use DPAD up/down to change target framerate.
Press X to toggle VSYNC on/off (only for 60 fps currently)

